### PR TITLE
Fixed re-namespace under Enqueue's organisation - invalid extension n…

### DIFF
--- a/Bundle/DependencyInjection/Configuration.php
+++ b/Bundle/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
 
         $treeBuilder
-            ->root('enqueue_bridge')
+            ->root('enqueue_adapter')
                 ->canBeDisabled()
                 ->children()
                     ->scalarNode('queue')->isRequired()->end()

--- a/Bundle/DependencyInjection/EnqueueAdapterExtension.php
+++ b/Bundle/DependencyInjection/EnqueueAdapterExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class EnqueueBridgeExtension extends Extension
+class EnqueueAdapterExtension extends Extension
 {
     /**
      * {@inheritdoc}
@@ -36,7 +36,7 @@ class EnqueueBridgeExtension extends Extension
         ));
 
         $receiverDefinition = new Definition(QueueInteropReceiver::class, array(
-            new Reference('messenger.transport.default_decoder'),
+            new Reference('messenger.transport.serializer'),
             $contextManager,
             $config['queue'],
             $config['topic'] ?: 'messages',
@@ -45,7 +45,7 @@ class EnqueueBridgeExtension extends Extension
         $receiverDefinition->addTag('messenger.receiver');
 
         $senderDefinition = new Definition(QueueInteropSender::class, array(
-            new Reference('messenger.transport.default_encoder'),
+            new Reference('messenger.transport.serializer'),
             $contextManager,
             $config['queue'],
             $config['topic'] ?: 'messages',

--- a/Tests/Bundle/DependencyInjection/EnqueueBridgeExtensionTest.php
+++ b/Tests/Bundle/DependencyInjection/EnqueueBridgeExtensionTest.php
@@ -12,7 +12,7 @@
 namespace Enqueue\MessengerAdapter\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Enqueue\MessengerAdapter\Bundle\DependencyInjection\EnqueueBridgeExtension;
+use Enqueue\MessengerAdapter\Bundle\DependencyInjection\EnqueueAdapterExtension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
 use Prophecy\Argument;
@@ -24,12 +24,12 @@ class EnqueueBridgeExtensionTest extends TestCase
 
     public function setUp()
     {
-        $this->extension = new EnqueueBridgeExtension();
+        $this->extension = new EnqueueAdapterExtension();
     }
 
     public function testConstruct()
     {
-        $this->extension = new EnqueueBridgeExtension();
+        $this->extension = new EnqueueAdapterExtension();
         $this->assertInstanceOf(ExtensionInterface::class, $this->extension);
         $this->assertInstanceOf(ConfigurationExtensionInterface::class, $this->extension);
     }


### PR DESCRIPTION
…ame, configuration root node must match normalized bundle name. Fixed default transport encoder/decoder service reference.