### PR TITLE
Bugs in messenger-adapter

### DIFF
--- a/Bundle/Resources/config/services.yml
+++ b/Bundle/Resources/config/services.yml
@@ -2,9 +2,8 @@ services:
     enqueue.messenger_transport.factory:
         class: 'Enqueue\MessengerAdapter\QueueInteropTransportFactory'
         arguments:
-            - "@messenger.transport.decoder"
-            - "@messenger.transport.encoder"
-            - "@service_container"
-            - "%kernel.debug%"
-        tags:
-            - 'messenger.transport_factory'
+            - '@messenger.transport.decoder'
+            - '@messenger.transport.encoder'
+            - '@service_container'
+            - '%kernel.debug%'
+        tags: ['messenger.transport_factory']

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ enqueue://default
     ?queue[name]=queue_name
     &topic[name]=topic_name
     &deliveryDelay=1800
-    &timeToLime=3600
+    &delayStrategy=Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy
+    &timeToLive=3600
+    &receiveTimeout=1000
     &priority=1
 ```

--- a/Tests/MessageBusProcessorTest.php
+++ b/Tests/MessageBusProcessorTest.php
@@ -12,6 +12,7 @@
 namespace Enqueue\MessengerAdapter\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
 use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -39,6 +40,7 @@ class MessageBusProcessorTest extends TestCase
     {
         $message = $this->getTestMessage();
         $receivedMessage = new ReceivedMessage('test');
+        $envelope = new Envelope($receivedMessage);
         $contextProphecy = $this->prophesize(PsrContext::class);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled();
@@ -47,8 +49,7 @@ class MessageBusProcessorTest extends TestCase
             'body' => 'body',
             'headers' => array('header'),
             'properties' => 'props',
-        ))->shouldBeCalled()->willReturn($receivedMessage);
-
+        ))->shouldBeCalled()->willReturn($envelope);
         $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
         $this->assertSame(PsrProcessor::ACK, $messageBusProcessor->process($message, $contextProphecy->reveal()));
     }
@@ -57,12 +58,12 @@ class MessageBusProcessorTest extends TestCase
     {
         $message = $this->getTestMessage();
         $receivedMessage = new ReceivedMessage('test');
+        $envelope = new Envelope($receivedMessage);
         $contextProphecy = $this->prophesize(PsrContext::class);
         $decoderProphecy = $this->prophesize(DecoderInterface::class);
-        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($receivedMessage);
+        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($envelope);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new RejectMessageException());
-
         $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
         $this->assertSame(PsrProcessor::REJECT, $messageBusProcessor->process($message, $contextProphecy->reveal()));
     }
@@ -71,12 +72,12 @@ class MessageBusProcessorTest extends TestCase
     {
         $message = $this->getTestMessage();
         $receivedMessage = new ReceivedMessage('test');
+        $envelope = new Envelope($receivedMessage);
         $contextProphecy = $this->prophesize(PsrContext::class);
         $decoderProphecy = $this->prophesize(DecoderInterface::class);
-        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($receivedMessage);
+        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($envelope);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new RequeueMessageException());
-
         $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
         $this->assertSame(PsrProcessor::REQUEUE, $messageBusProcessor->process($message, $contextProphecy->reveal()));
     }
@@ -85,12 +86,12 @@ class MessageBusProcessorTest extends TestCase
     {
         $message = $this->getTestMessage();
         $receivedMessage = new ReceivedMessage('test');
+        $envelope = new Envelope($receivedMessage);
         $contextProphecy = $this->prophesize(PsrContext::class);
         $decoderProphecy = $this->prophesize(DecoderInterface::class);
-        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($receivedMessage);
+        $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($envelope);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new \InvalidArgumentException());
-
         $messageBusProcessor = new MessageBusProcessor($busProphecy->reveal(), $decoderProphecy->reveal());
         $this->assertSame(PsrProcessor::REJECT, $messageBusProcessor->process($message, $contextProphecy->reveal()));
     }

--- a/Tests/QueueInteropTransportFactoryTest.php
+++ b/Tests/QueueInteropTransportFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Enqueue\MessengerAdapter\Tests;
 
+use Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy;
 use Enqueue\MessengerAdapter\QueueInteropTransport;
 use Enqueue\MessengerAdapter\QueueInteropTransportFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -51,16 +52,48 @@ class QueueInteropTransportFactoryTest extends TestCase
         $this->assertEquals($expectedTransport, $factory->createReceiver($dsn, array()));
     }
 
+    public function testDnsParsing()
+    {
+        $queuePsrContext = $this->prophesize(PsrContext::class)->reveal();
+        $decoder = $this->prophesize(DecoderInterface::class);
+        $encoder = $this->prophesize(EncoderInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('enqueue.transport.default.context')->willReturn(true);
+        $container->get('enqueue.transport.default.context')->willReturn($queuePsrContext);
+
+        $factory = $this->getFactory($decoder->reveal(), $encoder->reveal(), $container->reveal());
+        $dsn = 'enqueue://default?queue[name]=test&topic[name]=test&deliveryDelay=100&delayStrategy=Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy&timeToLive=100&receiveTimeout=100&priority=100';
+
+        $expectedTransport = new QueueInteropTransport(
+            $decoder->reveal(),
+            $encoder->reveal(),
+            new AmqpContextManager($queuePsrContext),
+            array(
+                'topic' => array('name' => 'test'),
+                'queue' => array('name' => 'test'),
+                'deliveryDelay' => 100,
+                'delayStrategy' => RabbitMqDelayPluginDelayStrategy::class,
+                'priority' => 100,
+                'timeToLive' => 100,
+                'receiveTimeout' => 100,
+            ),
+            true
+        );
+
+        $this->assertEquals($expectedTransport, $factory->createTransport($dsn, array()));
+
+        // Ensure BC for Symfony beta 4.1
+        $this->assertEquals($expectedTransport, $factory->createSender($dsn, array()));
+        $this->assertEquals($expectedTransport, $factory->createReceiver($dsn, array()));
+    }
+
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Can't find Enqueue's transport named "foo": Service "enqueue.transport.foo.context" is not found.
      */
     public function testItThrowsAnExceptionWhenContextDoesNotExist()
     {
-        $queuePsrContext = $this->prophesize(PsrContext::class);
-        $decoder = $this->prophesize(DecoderInterface::class);
-        $encoder = $this->prophesize(EncoderInterface::class);
-
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('enqueue.transport.foo.context')->willReturn(false);
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     ],
     "require": {
         "enqueue/enqueue-bundle": "^0.8.0",
-        "symfony/messenger": "^4.1@dev"
+        "symfony/messenger": "^4.1.0",
+        "symfony/options-resolver": "^4.1",
+        "enqueue/amqp-tools": "^0.8.23"
     },
     "autoload": {
         "psr-4": { "Enqueue\\MessengerAdapter\\": "" }


### PR DESCRIPTION
https://github.com/php-enqueue/messenger-adapter/issues/6

Hi, i tried to use messenger-adapter and found few bugs:

1. `QueueInteropTransport::send` dont implement `TransportInterface`:
`Compile Error: Declaration of Enqueue\\MessengerAdapter\\QueueInteropTransport::send($message): void must be compatible with Symfony\\Component\\Messenger\\Transport\\SenderInterface::send(Symfony\\Component\\Messenger\\Envelope $envelope)`
1. If options `deliveryDelay` is true, must be call `producer::setDelayStrategy` method