### PR TITLE
Add AMQP topic exchange handling

### DIFF
--- a/AmqpContextManager.php
+++ b/AmqpContextManager.php
@@ -58,15 +58,19 @@ class AmqpContextManager implements ContextManager
         }
 
         $topic = $this->context->createTopic($destination['topic']);
-        $topic->setType(AmqpTopic::TYPE_FANOUT);
-        $topic->addFlag(AmqpTopic::FLAG_DURABLE);
+        $topic->setType($destination['topicOptions']['type'] ?? AmqpTopic::TYPE_FANOUT);
+        $topicFlags = $destination['topicOptions']['flags'] ?? ((int) $topic->getFlags() | AmqpTopic::FLAG_DURABLE);
+        $topic->setFlags($topicFlags);
         $this->context->declareTopic($topic);
 
         $queue = $this->context->createQueue($destination['queue']);
-        $queue->addFlag(AmqpQueue::FLAG_DURABLE);
+        $queueFlags = $destination['queueOptions']['flags'] ?? ((int) $queue->getFlags() | AmqpQueue::FLAG_DURABLE);
+        $queue->setFlags($queueFlags);
         $this->context->declareQueue($queue);
 
-        $this->context->bind(new AmqpBind($queue, $topic));
+        $this->context->bind(
+            new AmqpBind($queue, $topic, $destination['queueOptions']['bindingKey'] ?? null)
+        );
 
         return true;
     }

--- a/EnvelopeItem/TransportConfiguration.php
+++ b/EnvelopeItem/TransportConfiguration.php
@@ -33,6 +33,7 @@ final class TransportConfiguration implements StampInterface, \Serializable
     public function __construct(array $configuration)
     {
         $this->topic = $configuration['topic'] ?? null;
+        $this->metadata = $configuration['metadata'] ?? array();
     }
 
     /**
@@ -46,12 +47,23 @@ final class TransportConfiguration implements StampInterface, \Serializable
     }
 
     /**
+     * Get routing key.
+     *
+     * @return string $metadata
+     */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+
+    /**
      * Serialize object.
      */
     public function serialize()
     {
         return serialize(array(
             'topic' => $this->topic,
+            'metadata' => $this->metadata,
         ));
     }
 
@@ -62,8 +74,14 @@ final class TransportConfiguration implements StampInterface, \Serializable
      */
     public function unserialize($serialized)
     {
-        list('topic' => $topic) = unserialize($serialized, array('allowed_classes' => false));
+        list(
+            'topic' => $topic,
+            'metadata' => $metadata
+        ) = unserialize($serialized, array('allowed_classes' => false));
 
-        $this->__construct(array('topic' => $topic));
+        $this->__construct(array(
+            'topic' => $topic,
+            'metadata' => $metadata,
+        ));
     }
 }

--- a/Exception/MissingMessageMetadataSetterException.php
+++ b/Exception/MissingMessageMetadataSetterException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enqueue\MessengerAdapter\Exception;
+
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+
+class MissingMessageMetadataSetterException extends \LogicException implements ExceptionInterface
+{
+    public function __construct(string $metadata, string $setter, string $class)
+    {
+        parent::__construct(sprintf(
+            'Missing "%s" setter for "%s" metadata key in "%s" class',
+            $setter,
+            $metadata,
+            $class
+        ));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ bin/console messenger:consume-messages amqp
 
 ### Configure the queue(s) and exchange(s)
 
-In the transport DSN, you can add extra configuration. Here is the reference DSN (note that the values are just for the example):
+In the transport DSN, you can add extra configuration. Here is the common reference DSN (note that the values are just for the example):
 
 ```
 enqueue://default
@@ -71,6 +71,7 @@ enqueue://default
 
 You can send a message on a specific topic using `TransportConfiguration` envelope item with your message:
 ```php
+use Symfony\Component\Messenger\Envelope;
 use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 
 // ...
@@ -78,4 +79,32 @@ use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 $this->bus->dispatch((new Envelope($message))->with(new TransportConfiguration(
     ['topic' => 'specific-topic']
 )));
+```
+
+### Use AMQP topic exchange
+
+See https://www.rabbitmq.com/tutorials/tutorial-five-php.html
+
+You can use specific topic and queue options to configure your AMQP exchange in `topic` mode and bind it:
+```
+enqueue://default
+    ?queue[name]=queue_name
+    &queue[bindingKey]=foo.#
+    &topic[name]=topic_name
+    &topic[type]=topic
+    &deliveryDelay=1800
+    &delayStrategy=Enqueue\AmqpTools\RabbitMqDelayPluginDelayStrategy
+    &timeToLive=3600
+    &receiveTimeout=1000
+    &priority=1
+```
+
+Here is the way to send a message with a routing key matching this consumer:
+```php
+$this->bus->dispatch((new Envelope($message))->with(new TransportConfiguration([
+    'topic' => 'topic_name',
+    'metadata' => [
+        'routingKey' => 'foo.bar'
+    ]
+])));
 ```

--- a/Tests/AmqpContextManagerTest.php
+++ b/Tests/AmqpContextManagerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enqueue\MessengerAdapter\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Interop\Amqp\AmqpContext;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\Impl\AmqpBind;
+use Interop\Queue\Context;
+use Enqueue\MessengerAdapter\AmqpContextManager;
+
+class AmqpContextManagerTest extends TestCase
+{
+    private function getContextManager($topicName, $queueName, $topicType = null, $topicFlags = null, $queueBindingKey = null, $queueFlags = null)
+    {
+        $topicProphecy = $this->prophesize(AmqpTopic::class);
+        $topicProphecy->setType($topicType ?? AmqpTopic::TYPE_FANOUT)->shouldBeCalled();
+        if (null === $topicFlags) {
+            $topicProphecy->getFlags()->shouldBeCalled()->willReturn(AmqpTopic::FLAG_PASSIVE);
+        }
+        $topicProphecy->setFlags($topicFlags ?? (AmqpTopic::FLAG_DURABLE | AmqpTopic::FLAG_PASSIVE))->shouldBeCalled();
+        $topic = $topicProphecy->reveal();
+
+        $queueProphecy = $this->prophesize(AmqpQueue::class);
+        if (null === $queueFlags) {
+            $queueProphecy->getFlags()->shouldBeCalled()->willReturn(AmqpQueue::FLAG_PASSIVE);
+        }
+        $queueProphecy->setFlags($queueFlags ?? (AmqpQueue::FLAG_DURABLE | AmqpQueue::FLAG_PASSIVE))->shouldBeCalled();
+        $queue = $queueProphecy->reveal();
+
+        $bind = new AmqpBind($queue, $topic, $queueBindingKey);
+
+        $contextProphecy = $this->prophesize(AmqpContext::class);
+        $contextProphecy->createTopic($topicName)->shouldBeCalled()->willReturn($topic);
+        $contextProphecy->declareTopic($topic)->shouldBeCalled();
+        $contextProphecy->createQueue($queueName)->shouldBeCalled()->willReturn($queue);
+        $contextProphecy->declareQueue($queue)->shouldBeCalled();
+        $contextProphecy->bind($bind)->shouldBeCalled();
+        $context = $contextProphecy->reveal();
+
+        return new AmqpContextManager($context);
+    }
+
+    public function testDefaultEnsure()
+    {
+        $topicName = 'foo';
+        $queueName = 'bar';
+        $contextManager = $this->getContextManager($topicName, $queueName);
+
+        $this->assertTrue($contextManager->ensureExists(array(
+            'topic' => $topicName,
+            'topicOptions' => array('name' => $topicName),
+            'queue' => $queueName,
+            'queueOptions' => array('name' => $queueName),
+        )));
+    }
+
+    public function testCustomizedEnsure()
+    {
+        $topicName = 'foo';
+        $queueName = 'bar';
+        $topicType = 'topic';
+        $topicFlags = '8';
+        $queueFlags = 16;
+        $queueBindingKey = 'foo.#';
+        $contextManager = $this->getContextManager($topicName, $queueName, $topicType, $topicFlags, $queueBindingKey, $queueFlags);
+
+        $this->assertTrue($contextManager->ensureExists(array(
+            'topic' => $topicName,
+            'topicOptions' => array('name' => $topicName, 'type' => $topicType, 'flags' => $topicFlags),
+            'queue' => $queueName,
+            'queueOptions' => array('name' => $queueName, 'bindingKey' => $queueBindingKey, 'flags' => $queueFlags),
+        )));
+    }
+
+    public function testNotProcessedEnsure()
+    {
+        $topicName = 'foo';
+        $queueName = 'bar';
+
+        $contextProphecy = $this->prophesize(Context::class);
+        $context = $contextProphecy->reveal();
+
+        $contextManager = new AmqpContextManager($context);
+
+        $this->assertFalse($contextManager->ensureExists(array(
+            'topic' => $topicName,
+            'topicOptions' => array('name' => $topicName),
+            'queue' => $queueName,
+            'queueOptions' => array('name' => $queueName),
+        )));
+    }
+
+    public function testContextRetrieving()
+    {
+        $contextProphecy = $this->prophesize(Context::class);
+        $context = $contextProphecy->reveal();
+
+        $contextManager = new AmqpContextManager($context);
+
+        $this->assertSame($context, $contextManager->Context());
+    }
+
+    /* public function testExceptionRecovering()
+    {
+        $topicName = 'foo';
+        $queueName = 'bar';
+        $contextManager = $this->getContextManager($topicName, $queueName);
+
+        $exception = new \AMQPQueueException('', 404); // Class 'AMQPQueueException' not found
+
+        $this->assertTrue($contextManager->recoverException($exception, array(
+            'topic' => $topicName,
+            'topicOptions' => array('name' => $topicName),
+            'queue' => $queueName,
+            'queueOptions' => array('name' => $queueName),
+        )));
+    } */
+}

--- a/Tests/EnvelopeItem/TransportConfigurationTest.php
+++ b/Tests/EnvelopeItem/TransportConfigurationTest.php
@@ -22,9 +22,25 @@ class TransportConfigurationTest extends TestCase
         $this->assertSame('foo', $transportConfiguration->getTopic());
     }
 
+    public function testMetadataConfiguration()
+    {
+        $transportConfiguration = new TransportConfiguration(array('metadata' => array('foo' => 'bar')));
+        $this->assertEquals(array('foo' => 'bar'), $transportConfiguration->getMetadata());
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $transportConfiguration = new TransportConfiguration(array());
+        $this->assertNull($transportConfiguration->getTopic());
+        $this->assertEquals(array(), $transportConfiguration->getMetadata());
+    }
+
     public function testSerialization()
     {
-        $transportConfiguration = new TransportConfiguration(array('topic' => 'foo'));
+        $transportConfiguration = new TransportConfiguration(array(
+            'topic' => 'foo',
+            'metadata' => array('foo' => 'bar'),
+        ));
         $this->assertEquals($transportConfiguration, unserialize(serialize($transportConfiguration)));
     }
 }

--- a/Tests/Exception/MissingMessageMetadataSetterExceptionTest.php
+++ b/Tests/Exception/MissingMessageMetadataSetterExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enqueue\MessengerAdapter\Tests\EnvelopeItem;
+
+use PHPUnit\Framework\TestCase;
+use Enqueue\MessengerAdapter\Exception\MissingMessageMetadataSetterException;
+
+class MissingMessageMetadataSetterExceptionTest extends TestCase
+{
+    public function testMessage()
+    {
+        $exception = new MissingMessageMetadataSetterException('foo', 'setFoo', 'Foo');
+        $this->assertSame(
+            'Missing "setFoo" setter for "foo" metadata key in "Foo" class',
+            $exception->getMessage()
+        );
+    }
+}

--- a/Tests/Fixtures/DecoratedPsrMessage.php
+++ b/Tests/Fixtures/DecoratedPsrMessage.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Enqueue\MessengerAdapter\Tests\Fixtures;
+
+use Interop\Queue\Message;
+
+class DecoratedPsrMessage implements Message
+{
+    /**
+     * @var string
+     */
+    private $body;
+
+    /**
+     * @var array
+     */
+    private $properties;
+
+    /**
+     * @var array
+     */
+    private $headers;
+
+    /**
+     * @var string|null
+     */
+    private $deliveryTag;
+
+    /**
+     * @var string|null
+     */
+    private $consumerTag;
+
+    /**
+     * @var bool
+     */
+    private $redelivered;
+
+    /**
+     * @var int
+     */
+    private $flags;
+
+    /**
+     * @var string
+     */
+    private $routingKey;
+
+    /**
+     * @param string $body
+     * @param array  $properties
+     * @param array  $headers
+     */
+    public function __construct($body = '', array $properties = array(), array $headers = array())
+    {
+        $this->body = $body;
+        $this->properties = $properties;
+        $this->headers = $headers;
+
+        $this->redelivered = false;
+        $this->flags = self::FLAG_NOPARAM;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBody(string $body): void
+    {
+        $this->body = $body;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProperties(array $properties): void
+    {
+        $this->properties = $properties;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProperty(string $name, $value): void
+    {
+        $this->properties[$name] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProperty(string $name, $default = null)
+    {
+        return array_key_exists($name, $this->properties) ? $this->properties[$name] : $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setHeaders(array $headers): void
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setHeader(string $name, $value): void
+    {
+        $this->headers[$name] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHeader(string $name, $default = null)
+    {
+        return array_key_exists($name, $this->headers) ? $this->headers[$name] : $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRedelivered(bool $redelivered): void
+    {
+        $this->redelivered = (bool) $redelivered;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRedelivered(): bool
+    {
+        return $this->redelivered;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCorrelationId(?string $correlationId = null): void
+    {
+        $this->setHeader('correlation_id', $correlationId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCorrelationId(): ?string
+    {
+        return $this->getHeader('correlation_id');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMessageId(?string $messageId = null): void
+    {
+        $this->setHeader('message_id', $messageId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageId(): ?string
+    {
+        return $this->getHeader('message_id');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTimestamp(): ?int
+    {
+        $value = $this->getHeader('timestamp');
+
+        return null === $value ? null : (int) $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTimestamp(?int $timestamp = null): void
+    {
+        $this->setHeader('timestamp', $timestamp);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setReplyTo(?string $replyTo = null): void
+    {
+        $this->setHeader('reply_to', $replyTo);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReplyTo(): ?string
+    {
+        return $this->getHeader('reply_to');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRoutingKey(?string $routingKey = null): void
+    {
+        $this->routingKey = $routingKey;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoutingKey(): ?string
+    {
+        return $this->routingKey;
+    }
+}


### PR DESCRIPTION
The main goal of this pull request is to allow use of AMQP topic exchange (https://www.rabbitmq.com/tutorials/tutorial-five-php.html) but certainly allow much more.

Integration tests on a real app: DONE

_Note: I made the implementation in the idea of only impacting this repository and avoiding breaking changes but one can probably imagine a better implementation impacting several repositories with some breaking changes._

#22 