### PR TITLE
Support for EnqueueBundle 0.9.x-dev

### DIFF
--- a/AmqpContextManager.php
+++ b/AmqpContextManager.php
@@ -15,23 +15,23 @@ use Interop\Amqp\AmqpContext;
 use Interop\Amqp\AmqpQueue;
 use Interop\Amqp\AmqpTopic;
 use Interop\Amqp\Impl\AmqpBind;
-use Interop\Queue\PsrContext;
+use Interop\Queue\Context;
 
 class AmqpContextManager implements ContextManager
 {
-    private $psrContext;
+    private $context;
 
-    public function __construct(PsrContext $psrContext)
+    public function __construct(Context $context)
     {
-        $this->psrContext = $psrContext;
+        $this->context = $context;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function psrContext(): PsrContext
+    public function context(): Context
     {
-        return $this->psrContext;
+        return $this->context;
     }
 
     /**
@@ -53,20 +53,20 @@ class AmqpContextManager implements ContextManager
      */
     public function ensureExists(array $destination): bool
     {
-        if (!$this->psrContext instanceof AmqpContext) {
+        if (!$this->context instanceof AmqpContext) {
             return false;
         }
 
-        $topic = $this->psrContext->createTopic($destination['topic']);
+        $topic = $this->context->createTopic($destination['topic']);
         $topic->setType(AmqpTopic::TYPE_FANOUT);
         $topic->addFlag(AmqpTopic::FLAG_DURABLE);
-        $this->psrContext->declareTopic($topic);
+        $this->context->declareTopic($topic);
 
-        $queue = $this->psrContext->createQueue($destination['queue']);
+        $queue = $this->context->createQueue($destination['queue']);
         $queue->addFlag(AmqpQueue::FLAG_DURABLE);
-        $this->psrContext->declareQueue($queue);
+        $this->context->declareQueue($queue);
 
-        $this->psrContext->bind(new AmqpBind($queue, $topic));
+        $this->context->bind(new AmqpBind($queue, $topic));
 
         return true;
     }

--- a/Bundle/Resources/config/services.yml
+++ b/Bundle/Resources/config/services.yml
@@ -2,8 +2,8 @@ services:
     enqueue.messenger_transport.factory:
         class: 'Enqueue\MessengerAdapter\QueueInteropTransportFactory'
         arguments:
-            - '@messenger.transport.decoder'
-            - '@messenger.transport.encoder'
+            - '@messenger.transport.serializer'
+            - '@messenger.transport.serializer'
             - '@service_container'
             - '%kernel.debug%'
         tags: ['messenger.transport_factory']

--- a/ContextManager.php
+++ b/ContextManager.php
@@ -11,7 +11,7 @@
 
 namespace Enqueue\MessengerAdapter;
 
-use Interop\Queue\PsrContext;
+use Interop\Queue\Context;
 
 /**
  * It is reponsible of managing the queue context. It will ensure the queue is successfully created
@@ -22,11 +22,11 @@ use Interop\Queue\PsrContext;
 interface ContextManager
 {
     /**
-     * Returns the associated `PsrContext` object.
+     * Returns the associated `context` object.
      *
-     * @return PsrContext
+     * @return Context
      */
-    public function psrContext(): PsrContext;
+    public function context(): Context;
 
     /**
      * Recover from the given exception. This can typically be something like the queue or topic do not exists.

--- a/QueueInteropTransportFactory.php
+++ b/QueueInteropTransportFactory.php
@@ -11,14 +11,13 @@
 
 namespace Enqueue\MessengerAdapter;
 
-use Interop\Queue\PsrContext;
+use Interop\Queue\Context;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Messenger\Transport\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\SenderInterface;
-use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
-use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
  * Symfony Messenger transport factory.
@@ -32,7 +31,7 @@ class QueueInteropTransportFactory implements TransportFactoryInterface
     private $debug;
     private $container;
 
-    public function __construct(DecoderInterface $decoder, EncoderInterface $encoder, ContainerInterface $container, bool $debug = false)
+    public function __construct(SerializerInterface $decoder, SerializerInterface $encoder, ContainerInterface $container, bool $debug = false)
     {
         $this->encoder = $encoder;
         $this->decoder = $decoder;
@@ -92,13 +91,13 @@ class QueueInteropTransportFactory implements TransportFactoryInterface
             ));
         }
 
-        $psrContext = $this->container->get($contextService);
-        if (!$psrContext instanceof PsrContext) {
-            throw new \RuntimeException(sprintf('Service "%s" not instanceof PsrContext', $contextService));
+        $context = $this->container->get($contextService);
+        if (!$context instanceof Context) {
+            throw new \RuntimeException(sprintf('Service "%s" not instanceof context', $contextService));
         }
 
         return array(
-            new AmqpContextManager($psrContext),
+            new AmqpContextManager($context),
             $amqpOptions,
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "enqueue/enqueue-bundle": "^0.8.0",
-        "symfony/messenger": "^4.1.0",
-        "symfony/options-resolver": "^3.4|^4.1",
-        "enqueue/amqp-tools": "^0.8.23"
+        "enqueue/enqueue-bundle": "^0.9@dev",
+        "symfony/messenger": "^4.2@dev",
+        "symfony/options-resolver": "^3.4|^4.2",
+        "enqueue/amqp-tools": "^0.9@dev"
     },
     "autoload": {
         "psr-4": { "Enqueue\\MessengerAdapter\\": "" }


### PR DESCRIPTION
This is an attempt to bump versions in order to support `enqueue/enqueue-bundle[0.9.x-dev]`.

* Fixed `MessageBusProcessor` tests
* Fixed `QueueInterop` related tests and refactored code
* Refactored `AmqpContextManager`
* Refactored `ContextManager` interface
* Bumped versions