### PR TITLE
Support for v4.2 of symfony/messenger bundle

### DIFF
--- a/Bundle/Resources/config/services.yml
+++ b/Bundle/Resources/config/services.yml
@@ -2,8 +2,7 @@ services:
     enqueue.messenger_transport.factory:
         class: 'Enqueue\MessengerAdapter\QueueInteropTransportFactory'
         arguments:
-            - '@messenger.transport.decoder'
-            - '@messenger.transport.encoder'
+            - '@messenger.transport.serializer'
             - '@service_container'
             - '%kernel.debug%'
         tags: ['messenger.transport_factory']

--- a/MessageBusProcessor.php
+++ b/MessageBusProcessor.php
@@ -16,7 +16,7 @@ use Interop\Queue\PsrMessage;
 use Interop\Queue\PsrProcessor;
 use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Enqueue\MessengerAdapter\Exception\RejectMessageException;
 use Enqueue\MessengerAdapter\Exception\RequeueMessageException;
 
@@ -31,7 +31,7 @@ class MessageBusProcessor implements PsrProcessor
     private $bus;
     private $messageDecoder;
 
-    public function __construct(MessageBusInterface $bus, DecoderInterface $messageDecoder)
+    public function __construct(MessageBusInterface $bus, SerializerInterface $messageDecoder)
     {
         $this->bus = $bus;
         $this->messageDecoder = $messageDecoder;

--- a/QueueInteropTransport.php
+++ b/QueueInteropTransport.php
@@ -17,8 +17,7 @@ use Enqueue\AmqpTools\RabbitMqDlxDelayStrategy;
 use Enqueue\MessengerAdapter\Exception\RejectMessageException;
 use Enqueue\MessengerAdapter\Exception\RequeueMessageException;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
-use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Interop\Queue\Exception as InteropQueueException;
 use Enqueue\MessengerAdapter\Exception\SendingMessageFailedException;
@@ -34,17 +33,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class QueueInteropTransport implements TransportInterface
 {
-    private $decoder;
-    private $encoder;
+    private $serializer;
     private $contextManager;
     private $options;
     private $debug;
     private $shouldStop;
 
-    public function __construct(DecoderInterface $decoder, EncoderInterface $encoder, ContextManager $contextManager, array $options = array(), $debug = false)
+    public function __construct(SerializerInterface $serializer, ContextManager $contextManager, array $options = array(), $debug = false)
     {
-        $this->decoder = $decoder;
-        $this->encoder = $encoder;
+        $this->serializer = $serializer;
         $this->contextManager = $contextManager;
         $this->debug = $debug;
 
@@ -112,7 +109,7 @@ class QueueInteropTransport implements TransportInterface
             $this->contextManager->ensureExists($destination);
         }
 
-        $encodedMessage = $this->encoder->encode($message);
+        $encodedMessage = $this->serializer->encode($message);
 
         $psrMessage = $psrContext->createMessage(
             $encodedMessage['body'],

--- a/QueueInteropTransportFactory.php
+++ b/QueueInteropTransportFactory.php
@@ -17,8 +17,7 @@ use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Messenger\Transport\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\SenderInterface;
-use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
-use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
  * Symfony Messenger transport factory.
@@ -27,15 +26,13 @@ use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
  */
 class QueueInteropTransportFactory implements TransportFactoryInterface
 {
-    private $decoder;
-    private $encoder;
+    private $serializer;
     private $debug;
     private $container;
 
-    public function __construct(DecoderInterface $decoder, EncoderInterface $encoder, ContainerInterface $container, bool $debug = false)
+    public function __construct(SerializerInterface $serializer, ContainerInterface $container, bool $debug = false)
     {
-        $this->encoder = $encoder;
-        $this->decoder = $decoder;
+        $this->serializer = $serializer;
         $this->container = $container;
         $this->debug = $debug;
     }
@@ -57,8 +54,7 @@ class QueueInteropTransportFactory implements TransportFactoryInterface
         [$contextManager, $options] = $this->parseDsn($dsn);
 
         return new QueueInteropTransport(
-            $this->decoder,
-            $this->encoder,
+            $this->serializer,
             $contextManager,
             $options,
             $this->debug

--- a/Tests/MessageBusProcessorTest.php
+++ b/Tests/MessageBusProcessorTest.php
@@ -13,7 +13,7 @@ namespace Enqueue\MessengerAdapter\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Asynchronous\Transport\ReceivedMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Interop\Queue\PsrMessage;
@@ -44,7 +44,7 @@ class MessageBusProcessorTest extends TestCase
         $contextProphecy = $this->prophesize(PsrContext::class);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled();
-        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy = $this->prophesize(SerializerInterface::class);
         $decoderProphecy->decode(array(
             'body' => 'body',
             'headers' => array('header'),
@@ -60,7 +60,7 @@ class MessageBusProcessorTest extends TestCase
         $receivedMessage = new ReceivedMessage('test');
         $envelope = new Envelope($receivedMessage);
         $contextProphecy = $this->prophesize(PsrContext::class);
-        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy = $this->prophesize(SerializerInterface::class);
         $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($envelope);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new RejectMessageException());
@@ -74,7 +74,7 @@ class MessageBusProcessorTest extends TestCase
         $receivedMessage = new ReceivedMessage('test');
         $envelope = new Envelope($receivedMessage);
         $contextProphecy = $this->prophesize(PsrContext::class);
-        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy = $this->prophesize(SerializerInterface::class);
         $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($envelope);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new RequeueMessageException());
@@ -88,7 +88,7 @@ class MessageBusProcessorTest extends TestCase
         $receivedMessage = new ReceivedMessage('test');
         $envelope = new Envelope($receivedMessage);
         $contextProphecy = $this->prophesize(PsrContext::class);
-        $decoderProphecy = $this->prophesize(DecoderInterface::class);
+        $decoderProphecy = $this->prophesize(SerializerInterface::class);
         $decoderProphecy->decode(Argument::any())->shouldBeCalled()->willReturn($envelope);
         $busProphecy = $this->prophesize(MessageBusInterface::class);
         $busProphecy->dispatch($receivedMessage)->shouldBeCalled()->willThrow(new \InvalidArgumentException());

--- a/Tests/QueueInteropTransportTest.php
+++ b/Tests/QueueInteropTransportTest.php
@@ -23,11 +23,10 @@ use Interop\Queue\PsrDestination;
 use Interop\Queue\PsrMessage;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\SenderInterface;
-use Symfony\Component\Messenger\Transport\Serialization\EncoderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Enqueue\MessengerAdapter\ContextManager;
 use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 use Interop\Queue\Exception;
-use Symfony\Component\Messenger\Transport\Serialization\DecoderInterface;
 
 class QueueInteropTransportTest extends TestCase
 {
@@ -67,11 +66,10 @@ class QueueInteropTransportTest extends TestCase
         $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
         $contextManagerProphecy->ensureExists(array('topic' => $topic, 'queue' => $queue))->shouldBeCalled();
 
-        $encoderProphecy = $this->prophesize(EncoderInterface::class);
+        $encoderProphecy = $this->prophesize(SerializerInterface::class);
         $encoderProphecy->encode($envelope)->shouldBeCalled()->willReturn(array('body' => 'foo'));
 
         $transport = $this->getTransport(
-            null,
             $encoderProphecy->reveal(),
             $contextManagerProphecy->reveal(),
             array(
@@ -113,11 +111,10 @@ class QueueInteropTransportTest extends TestCase
         $contextManagerProphecy = $this->prophesize(ContextManager::class);
         $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
 
-        $encoderProphecy = $this->prophesize(EncoderInterface::class);
+        $encoderProphecy = $this->prophesize(SerializerInterface::class);
         $encoderProphecy->encode($envelope)->shouldBeCalled()->willReturn(array('body' => 'foo'));
 
         $transport = $this->getTransport(
-            null,
             $encoderProphecy->reveal(),
             $contextManagerProphecy->reveal(),
             array(
@@ -156,11 +153,10 @@ class QueueInteropTransportTest extends TestCase
         $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
         $contextManagerProphecy->ensureExists(array('topic' => $specificTopic, 'queue' => $queue))->shouldBeCalled();
 
-        $encoderProphecy = $this->prophesize(EncoderInterface::class);
+        $encoderProphecy = $this->prophesize(SerializerInterface::class);
         $encoderProphecy->encode($envelope)->shouldBeCalled()->willReturn(array('body' => 'foo'));
 
         $transport = $this->getTransport(
-            null,
             $encoderProphecy->reveal(),
             $contextManagerProphecy->reveal(),
             array(
@@ -203,11 +199,10 @@ class QueueInteropTransportTest extends TestCase
         $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
         $contextManagerProphecy->recoverException($exception, array('topic' => $topic, 'queue' => $queue))->shouldBeCalled()->willReturn(false);
 
-        $encoderProphecy = $this->prophesize(EncoderInterface::class);
+        $encoderProphecy = $this->prophesize(SerializerInterface::class);
         $encoderProphecy->encode($envelope)->shouldBeCalled()->willReturn(array('body' => 'foo'));
 
         $transport = $this->getTransport(
-            null,
             $encoderProphecy->reveal(),
             $contextManagerProphecy->reveal(),
             array(
@@ -235,7 +230,7 @@ class QueueInteropTransportTest extends TestCase
         $contextManagerProphecy = $this->prophesize(ContextManager::class);
         $contextManagerProphecy->psrContext()->shouldBeCalled()->willReturn($psrContextProphecy->reveal());
 
-        $transport = $this->getTransport(null, null, $contextManagerProphecy->reveal());
+        $transport = $this->getTransport(null, $contextManagerProphecy->reveal());
         $handlerArgument = 'not-null';
         $handler = function ($argument) use (&$handlerArgument, $transport) {
             $handlerArgument = $argument;
@@ -245,11 +240,10 @@ class QueueInteropTransportTest extends TestCase
         $this->assertNull($handlerArgument);
     }
 
-    private function getTransport(DecoderInterface $decoder = null, EncoderInterface $encoder = null, ContextManager $contextManager = null, array $options = array(), $debug = false)
+    private function getTransport(SerializerInterface $serializer = null, ContextManager $contextManager = null, array $options = array(), $debug = false)
     {
         return new QueueInteropTransport(
-            $decoder ?: $this->prophesize(DecoderInterface::class)->reveal(),
-            $encoder ?: $this->prophesize(EncoderInterface::class)->reveal(),
+            $serializer ?: $this->prophesize(SerializerInterface::class)->reveal(),
             $contextManager ?: $this->prophesize(ContextManager::class)->reveal(),
             $options,
             $debug

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "enqueue/enqueue-bundle": "^0.8.0",
-        "symfony/messenger": "^4.1.0",
+        "symfony/messenger": "^4.2@dev",
         "symfony/options-resolver": "^3.4|^4.1",
         "enqueue/amqp-tools": "^0.8.23"
     },


### PR DESCRIPTION
`symfony/messenger` replaced the encoder/decoder interfaces by a common `SerializerInterface`

> [BC BREAK] The EncoderInterface and DecoderInterface have been replaced by a unified Symfony\Component\Messenger\Transport\Serialization\SerializerInterface.