### PR TITLE
Update Travis matrix to have a global overview and to allow testing on beta version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,20 @@ cache:
 
 matrix:
   include:
-    - php: '7.1'
-    - php: '7.2'
+    - php: 7.1
+    - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+    - php: 7.2
+    - php: 7.2
+      env: COMPOSER_MINIMUM_STABILITY=beta
+    - php: 7.2
+      env: COMPOSER_MINIMUM_STABILITY=dev
+    - php: nightly
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: nightly
+    - env: COMPOSER_MINIMUM_STABILITY=dev
+    - env: COMPOSER_MINIMUM_STABILITY=beta
 
 before_install:
   - phpenv config-rm xdebug.ini || echo "xdebug not available"
@@ -17,7 +29,19 @@ before_install:
   - export PATH="$PATH:$HOME/.composer/vendor/bin"
 
 install:
-  - composer update --no-progress --no-suggest --ansi
+  - |
+    # Handle composer stability to ensure code is validated against all the versions
+    case "$COMPOSER_MINIMUM_STABILITY" in
+      dev|alpha|beta|rc|stable)
+        echo "Update stability requirement during the build to $COMPOSER_MINIMUM_STABILITY."
+        composer config minimum-stability $COMPOSER_MINIMUM_STABILITY
+        ;;
+
+      *)
+        echo "Use the stability defined in composer.json"
+        ;;
+    esac
+  - composer update ${COMPOSER_FLAGS} --no-progress --no-suggest --ansi
 
 script:
   - php-cs-fixer fix --dry-run --diff --no-ansi

--- a/composer.json
+++ b/composer.json
@@ -16,22 +16,22 @@
         }
     ],
     "require": {
-        "enqueue/enqueue-bundle": "^0.9@dev",
-        "symfony/messenger": "^4.2@dev",
+        "enqueue/enqueue-bundle": "^0.9",
+        "symfony/messenger": "^4.2",
         "symfony/options-resolver": "^3.4|^4.2",
-        "enqueue/amqp-tools": "^0.9@dev"
+        "enqueue/amqp-tools": "^0.9"
     },
     "autoload": {
         "psr-4": { "Enqueue\\MessengerAdapter\\": "" }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1@dev",
-        "symfony/yaml": "^3.4@dev|^4.1@dev"
+        "phpunit/phpunit": "^7.1",
+        "symfony/yaml": "^3.4|^4.1"
     }
 }


### PR DESCRIPTION
As we discussed in #36, this PR goal is to have a complete Travis matrix to : 

* Test on component's beta version
* Test on lowest dependency version

I've also updated the composer.json file which is currently in a "dev" minimum stability requirement. 

Regarding the test results, the current master branch is compatible with Symfony/Messenger 4.2 but not with the 4.1 version anymore…

What do you think about these details ?