### PR TITLE
Allow options to be passed via Symfony config, not just DSN

### DIFF
--- a/QueueInteropTransportFactory.php
+++ b/QueueInteropTransportFactory.php
@@ -49,7 +49,9 @@ class QueueInteropTransportFactory implements TransportFactoryInterface
 
     public function createTransport(string $dsn, array $options): TransportInterface
     {
-        [$contextManager, $options] = $this->parseDsn($dsn);
+        [$contextManager, $dsnOptions] = $this->parseDsn($dsn);
+
+        $options = array_merge($dsnOptions, $options);
 
         return new QueueInteropTransport(
             $this->serializer,


### PR DESCRIPTION
Symfony Messenger allows passing options via... well... options array. Adapter however completely ignores them.

```yaml
# Default configuration for extension with alias: "framework" at path "messenger"

# Messenger configuration
messenger:
    enabled:              false
    routing:

        # Prototype
        message_class:
            senders:              []
            send_and_handle:      false
    serializer:
        enabled:              false
        format:               json
        context:

            # Prototype
            name:                 ~
    encoder:              messenger.transport.serializer
    decoder:              messenger.transport.serializer
    transports:

        # Prototype
        name:
            dsn:                  ~
            ### This PR allows these options to be respected.
            options:              []
    default_bus:          null
    buses:

        # Prototype
        name:
            default_middleware:   true
            middleware:

                # Prototype
                -
                    id:                   ~ # Required
                    arguments:            []

```