### PR TITLE
Fixing serialization problems with ObjectNormalizer + more helpers

### DIFF
--- a/EnvelopeItem/TransportConfiguration.php
+++ b/EnvelopeItem/TransportConfiguration.php
@@ -11,6 +11,7 @@
 
 namespace Enqueue\MessengerAdapter\EnvelopeItem;
 
+use Enqueue\AmqpTools\DelayStrategy;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
@@ -22,20 +23,11 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
  */
 final class TransportConfiguration implements StampInterface, \Serializable
 {
-    /**
-     * @var string
-     */
     private $topic;
 
-    /**
-     * @var array
-     */
-    private $metadata;
+    private $metadata = array();
 
-    /**
-     * @param array $configuration
-     */
-    public function __construct(array $configuration)
+    public function __construct(array $configuration = array())
     {
         $this->topic = $configuration['topic'] ?? null;
         $this->metadata = $configuration['metadata'] ?? array();
@@ -58,9 +50,55 @@ final class TransportConfiguration implements StampInterface, \Serializable
         return $this->metadata;
     }
 
-    /**
-     * Serialize object.
-     */
+    public function setTopic($topic): self
+    {
+        $this->topic = $topic;
+
+        return $this;
+    }
+
+    public function setMetadata(array $metadata): self
+    {
+        $this->metadata = $metadata;
+
+        return $this;
+    }
+
+    public function addMetadata(string $key, $value): self
+    {
+        $this->metadata[$key] = $value;
+
+        return $this;
+    }
+
+    public function setPriority(int $priority = null): self
+    {
+        $this->metadata['priority'] = $priority;
+
+        return $this;
+    }
+
+    public function setDeliveryDelay(int $deliveryDelay = null): self
+    {
+        $this->metadata['deliveryDelay'] = $deliveryDelay;
+
+        return $this;
+    }
+
+    public function setDelayStrategy(DelayStrategy $delayStrategy = null): self
+    {
+        $this->metadata['delayStrategy'] = $delayStrategy;
+
+        return $this;
+    }
+
+    public function setTimeToLive(int $timeToLive = null): self
+    {
+        $this->metadata['timeToLive'] = $timeToLive;
+
+        return $this;
+    }
+
     public function serialize()
     {
         return serialize(array(
@@ -69,9 +107,6 @@ final class TransportConfiguration implements StampInterface, \Serializable
         ));
     }
 
-    /**
-     * Unserialize object.
-     */
     public function unserialize($serialized)
     {
         list(

--- a/README.md
+++ b/README.md
@@ -76,9 +76,16 @@ use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 
 // ...
 
-$this->bus->dispatch((new Envelope($message))->with(new TransportConfiguration(
-    ['topic' => 'specific-topic']
-)));
+$this->bus->dispatch((new Envelope($message))
+    ->with(
+        (new TransportConfiguration())
+            ->setTopic('specific-topic')
+            ->setDeliveryDelay(5000)
+            // any other metadata to set onto the message
+            // setRoutingKey() will be called on the Enqueue message
+            ->addMetadata('routingKey' => 'foo.bar')
+    )
+);
 ```
 
 ### Use AMQP topic exchange

--- a/Tests/EnvelopeItem/TransportConfigurationTest.php
+++ b/Tests/EnvelopeItem/TransportConfigurationTest.php
@@ -11,6 +11,7 @@
 
 namespace Enqueue\MessengerAdapter\Tests\EnvelopeItem;
 
+use Enqueue\AmqpTools\DelayStrategy;
 use PHPUnit\Framework\TestCase;
 use Enqueue\MessengerAdapter\EnvelopeItem\TransportConfiguration;
 
@@ -42,5 +43,36 @@ class TransportConfigurationTest extends TestCase
             'metadata' => array('foo' => 'bar'),
         ));
         $this->assertEquals($transportConfiguration, unserialize(serialize($transportConfiguration)));
+    }
+
+    public function testSettersForObjectNormalization()
+    {
+        $transportConfigurationA = new TransportConfiguration(array(
+            'topic' => 'foo',
+            'metadata' => array('foo' => 'bar'),
+        ));
+
+        $transportConfigurationB = new TransportConfiguration();
+        $transportConfigurationB->setTopic('foo');
+        $transportConfigurationB->setMetadata(array('foo' => 'bar'));
+
+        $this->assertEquals($transportConfigurationA, $transportConfigurationB);
+    }
+
+    public function testConvenienceSetters()
+    {
+        $transportConfiguration = new TransportConfiguration();
+        $delayStrategy = $this->createMock(DelayStrategy::class);
+        $transportConfiguration->setDelayStrategy($delayStrategy);
+        $transportConfiguration->setDeliveryDelay(100);
+        $transportConfiguration->setPriority(10);
+        $transportConfiguration->setTimeToLive(50);
+
+        $this->assertSame(array(
+            'delayStrategy' => $delayStrategy,
+            'deliveryDelay' => 100,
+            'priority' => 10,
+            'timeToLive' => 50,
+        ), $transportConfiguration->getMetadata());
     }
 }


### PR DESCRIPTION
The `TransportConfiguration` is currently broken for default Messenger installs because the default install uses the `ObjectNormalizer` for serialization, which causes several problems:

* The required constructor makes it not serializable
* Some of the incorrect phpdoc above the properties also caused it to fail

I've re-worked this class to play nicely with the ObjectNormalizer. AND, I've added methods for the most common options/methods that you'll want to configure on your message. This makes the experience a bit nicer, while still making the old way work

```php
// before (still works)
$envelope = (new Envelope($message))
    ->with(new TransportConfiguration(['metadata' => [
        'deliveryDelay' => 10000
    ]]))
;

// after
$envelope = (new Envelope($message))
    ->with((new TransportConfiguration())->setDeliveryDelay(10000))
;
```

Thanks!